### PR TITLE
Fix lint issues update

### DIFF
--- a/tests/testthat/test-validate_ensemble_inputs.R
+++ b/tests/testthat/test-validate_ensemble_inputs.R
@@ -56,14 +56,18 @@ test_that("weights column already in model_outputs generates error", {
 })
 
 test_that("no error if models provide the same output_type_ids", {
-  model_outputs |>
-    validate_output_type_ids(task_id_cols = c("location", "horizon", "target", "target_date")) |>
-    expect_no_error()
+  expect_no_error(
+    validate_output_type_ids(
+      model_outputs,
+      task_id_cols = c("location", "horizon", "target", "target_date")
+    )
+  )
 })
 
 test_that("error if models provide different output_type_ids", {
-  model_outputs |>
-    dplyr::filter(!(model_id == "b" & abs(output_type_id - 0.5) < 1e-6)) |>
-    validate_output_type_ids(task_id_cols = c("location", "horizon", "target", "target_date")) |>
-    expect_error()
+  expect_error(
+    model_outputs |>
+      dplyr::filter(!(model_id == "b" & abs(output_type_id - 0.5) < 1e-6)) |>
+      validate_output_type_ids(task_id_cols = c("location", "horizon", "target", "target_date"))
+  )
 })


### PR DESCRIPTION
I'm making a few edits here to get to a place where I think the code is more readable:

- I find large amounts of leading whitespace to be distracting
- In tests, I prefer a more declarative style where the expectation comes first rather than being called at the end of a sequence of pipes.

Both of these things can be addressed while still making the linter happy by putting closing `)` on a new line.